### PR TITLE
fixed npm typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project doesn't solve all edge cases... for those you can wire it up yourse
 
 
 ## Installation
-`npm install simple-redux-react --save`
+`npm install --save simple-react-redux`
 
 
 ## Configuration


### PR DESCRIPTION
i commented on an issue about this and went ahead and fixed the misleading install script.
- changed line 14 on the readme to say 

```
npm install --save simple-react-redux
```

vs

```
npm install simple-redux-react --save
```

excited to use this in my project
